### PR TITLE
Fix blinking status messages

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.cpp
@@ -42,6 +42,7 @@ const char *g_platform_name = PLATFORM_NAME;
 static uint32_t g_flash_chip_size = 0;
 static bool g_uart_initialized = false;
 static bool g_led_disabled = false;
+static bool g_led_blinking = false;
 static bool g_dip_drive_id, g_dip_cable_sel;
 static uint64_t g_flash_unique_id;
 
@@ -163,11 +164,23 @@ void platform_late_init()
 
 void platform_write_led(bool state)
 {
-    if (g_led_disabled) return;
+    if (g_led_disabled || g_led_blinking) return;
 
     gpio_put(STATUS_LED, state);
 }
 
+void platform_set_blink_status(bool status)
+{
+    g_led_blinking = status;
+}
+
+void platform_write_led_override(bool state)
+{
+    if (g_led_disabled) return;
+
+    gpio_put(STATUS_LED, state);
+
+}
 void platform_disable_led(void)
 {   
     g_led_disabled = true;

--- a/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
+++ b/lib/ZuluIDE_platform_RP2040/ZuluIDE_platform.h
@@ -56,8 +56,12 @@ void platform_late_init();
 
 // Write the status LED through the mux
 void platform_write_led(bool state);
-#define LED_ON() platform_write_led(true)
+#define LED_ON()  platform_write_led(true)
 #define LED_OFF() platform_write_led(false)
+void platform_set_blink_status(bool status);
+void platform_write_led_override(bool state);
+#define LED_ON_OVERRIDE()  platform_write_led_override(true)
+#define LED_OFF_OVERRIDE()  platform_write_led_override(false)
 
 // Disable the status LED
 void platform_disable_led(void);


### PR DESCRIPTION
Blinking status could be interrupted drive access blinking, thus confusing the status trying to be reported. Also the first blink wasn't always at the same rate as following blinks.

Now status blinking blocks normal LED changes and the blink rate is consistent.