### PR TITLE
Fix certain IDE controllers erroring out

### DIFF
--- a/lib/ZuluIDE_platform_RP2040/rp2040_ide_phy.cpp
+++ b/lib/ZuluIDE_platform_RP2040/rp2040_ide_phy.cpp
@@ -40,6 +40,8 @@ static struct {
 
 #define BLOCK_CRC_VALID 0x10000
 
+extern bool g_ignore_cmd_interrupt;
+
 // Compare the CRC we calculated with DMA when writing to FPGA
 // against the CRC received from the host in UltraDMA mode.
 static void verify_crc(uint32_t *block_crc)
@@ -162,8 +164,7 @@ bool ide_phy_is_command_interrupted()
 
     if (status & FPGA_STATUS_IDE_RST) return true;
     if (status & FPGA_STATUS_IDE_SRST) return true;
-    if (status & FPGA_STATUS_IDE_CMD) return true;
-
+    if (!g_ignore_cmd_interrupt && (status & FPGA_STATUS_IDE_CMD)) return true;
     return false;
 }
 

--- a/src/ZuluIDE.cpp
+++ b/src/ZuluIDE.cpp
@@ -288,7 +288,6 @@ void zuluide_setup(void)
     platform_init();
     platform_late_init();
     g_sdcard_present = mountSDCard();
-    bool sd_card_initialized = false;
     if(!g_sdcard_present)
     {
         logmsg("SD card init failed, sdErrorCode: ", (int)SD.sdErrorCode(),

--- a/src/ZuluIDE_config.h
+++ b/src/ZuluIDE_config.h
@@ -27,7 +27,7 @@
 #include <ZuluIDE_platform.h>
 
 // Use variables for version number
-#define FW_VER_NUM      "2024.04.04"
+#define FW_VER_NUM      "2024.04.08"
 #define FW_VER_SUFFIX   "devel"
 #define ZULU_FW_VERSION FW_VER_NUM "-" FW_VER_SUFFIX
 

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -52,6 +52,8 @@ static ide_registers_t g_prev_ide_regs;
 static int g_ide_busy_secs;
 static bool g_ide_reset_after_init_done;
 
+bool g_ignore_cmd_interrupt;
+
 static void do_phy_reset()
 {
     if (g_ide_config.enable_dev0 && !g_ide_config.enable_dev1)
@@ -321,6 +323,11 @@ void IDEDevice::initialize(int devidx)
     logmsg("-- Max UDMA mode: ", m_devconfig.max_udma_mode, " (phy max ", m_phy_caps.max_udma_mode, ")");
     logmsg("-- Max blocksize: ", m_devconfig.max_blocksize, " (phy max ", (int)m_phy_caps.max_blocksize, ")");
 
+    g_ignore_cmd_interrupt = ini_getl("IDE", "ignore_command_interrupt", 1, CONFIGFILE);
+    if (!g_ignore_cmd_interrupt)
+    {
+        logmsg("-- New commands may interrupt previous command - ignore_command_interrupt set to 0");
+    }
     m_phy_caps.max_udma_mode = std::min(m_phy_caps.max_udma_mode, m_devconfig.max_udma_mode);
     m_phy_caps.max_pio_mode = std::min(m_phy_caps.max_pio_mode, m_devconfig.max_pio_mode);
     m_phy_caps.max_blocksize = std::min<int>(m_phy_caps.max_blocksize, m_devconfig.max_blocksize);

--- a/src/ide_protocol.cpp
+++ b/src/ide_protocol.cpp
@@ -174,13 +174,15 @@ void ide_protocol_poll()
                 ide_phy_set_regs(&regs);
                 ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
             }
-            else if (ide_phy_is_command_interrupted())
-            {
-                logmsg("-- Command was interrupted");
-                regs.error = IDE_ERROR_ABORT;
-                ide_phy_set_regs(&regs);
-                ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
-            }
+            // \todo figure out if possibly reading the status from the FPGA is causing
+            // `ide_phy_is_command_interrupted` to crash the board on certain IDE controllers
+            // else if (ide_phy_is_command_interrupted())
+            // {
+            //     logmsg("-- Command was interrupted");
+            //     regs.error = IDE_ERROR_ABORT;
+            //     ide_phy_set_regs(&regs);
+            //     ide_phy_assert_irq(IDE_STATUS_DEVRDY | IDE_STATUS_ERR);
+            // }
             else
             {
                 dbgmsg("-- Command complete");

--- a/zuluide.ini
+++ b/zuluide.ini
@@ -9,3 +9,4 @@
 # reinsert_media_after_eject = 1 # Automatically reinsert media after eject 
 # reinsert_media_on_inquiry = 1  # Automaitcally reinsert media on inquiry command
 # has_drive1 = 0         # Force secondary drive detection result
+# ignore_command_interrupt = 1 # Ignore a new command interrupting the current one 


### PR DESCRIPTION
completely Remove/revert the check that was causing the issue with
the BeOS CD instead of just ignoring the `FPGA_STATUS_IDE_CMD`.
This is because the check was causing read issue with certain IDE controllers
with other CD images.

Commented the code out but left a `// \todo` comment as it might
be that reading the FPGA status command that is causing some sort of
timing issue.

The commented-out function call is also called in other code locations. 
It was noticed when install from a BeOS bin/cue image that the
device was failing a command if that FPGA status register had
`FPGA_STATUS_IDE_CMD` set. 

Though this check has been commented out, the ability to ignore the FPGA status `FPGA_STATUS_IDE_CMD`  by default still exists. It can be checked by setting `ignore_command_interrupt = 0` in the `zuluide.ini` file.